### PR TITLE
Include raw nunchuk accelerometer readings in nunchuck state

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -130,7 +130,7 @@ try:
     while wiimote:
         buttons_state = wiimote.get_buttons()
         nunchuk_buttons_state = wiimote.get_nunchuk_buttons()
-        joystick_state = wiimote.get_joystick_state()
+        joystick_state = wiimote.get_nunchuck_state()
 
         # Test if B or Z button is pressed
         if (

--- a/rc.py
+++ b/rc.py
@@ -20,7 +20,7 @@ class rc:
         while self.wiimote and not self.killed:
             buttons_state = self.wiimote.get_buttons()
             nunchuk_buttons_state = self.wiimote.get_nunchuk_buttons()
-            joystick_state = self.wiimote.get_joystick_state()
+            nunchuk_state = self.wiimote.get_nunchuck_state()
 
             # If 'C' is pressed, go to full speed
             if (nunchuk_buttons_state & cwiid.NUNCHUK_BTN_C):
@@ -42,7 +42,7 @@ class rc:
 
             # Get the normalised joystick postion as a tuple of
             # (throttle, steering), where values are in the range -1 to 1
-            joystick_pos = joystick_state['state']['normalised']
+            joystick_pos = nunchuk_state['state']['joystick']['normalised']
             throttle, steering = joystick_pos
             logging.info("mixing channels: {0} : {1}".format(throttle, steering))
             self.drive.mix_channels_and_assign(throttle, steering)


### PR DESCRIPTION
This should expose the raw nunchuk accelerometer readings as part of `get_nunchuk_state` (renamed from `get_joystick_state`.

Note _should_ - I don't have a wiimote to test this with :-)

It uses the cwiid state structure and constants from here: http://abstrakraft.org/cwiid/browser/wmdemo/wmdemo.py

Test before merging...
